### PR TITLE
The url was also wrong

### DIFF
--- a/models/convnext.py
+++ b/models/convnext.py
@@ -147,7 +147,7 @@ model_urls = {
     "convnext_tiny_1k": "https://dl.fbaipublicfiles.com/convnext/convnext_tiny_1k_224_ema.pth",
     "convnext_small_1k": "https://dl.fbaipublicfiles.com/convnext/convnext_small_1k_224_ema.pth",
     "convnext_base_1k": "https://dl.fbaipublicfiles.com/convnext/convnext_base_1k_224_ema.pth",
-    "convnext_xlarge_1k": "https://dl.fbaipublicfiles.com/convnext/convnext_large_1k_224_ema.pth",
+    "convnext_xlarge_1k": "https://dl.fbaipublicfiles.com/convnext/convnext_xlarge_1k_224_ema.pth",
     "convnext_base_22k": "https://dl.fbaipublicfiles.com/convnext/convnext_base_22k_224.pth",
     "convnext_large_22k": "https://dl.fbaipublicfiles.com/convnext/convnext_large_22k_224.pth",
     "convnext_xlarge_22k": "https://dl.fbaipublicfiles.com/convnext/convnext_xlarge_22k_224.pth",

--- a/models/convnext.py
+++ b/models/convnext.py
@@ -147,7 +147,7 @@ model_urls = {
     "convnext_tiny_1k": "https://dl.fbaipublicfiles.com/convnext/convnext_tiny_1k_224_ema.pth",
     "convnext_small_1k": "https://dl.fbaipublicfiles.com/convnext/convnext_small_1k_224_ema.pth",
     "convnext_base_1k": "https://dl.fbaipublicfiles.com/convnext/convnext_base_1k_224_ema.pth",
-    "convnext_large_1k": "https://dl.fbaipublicfiles.com/convnext/convnext_large_1k_224_ema.pth",
+    "convnext_xlarge_1k": "https://dl.fbaipublicfiles.com/convnext/convnext_large_1k_224_ema.pth",
     "convnext_base_22k": "https://dl.fbaipublicfiles.com/convnext/convnext_base_22k_224.pth",
     "convnext_large_22k": "https://dl.fbaipublicfiles.com/convnext/convnext_large_22k_224.pth",
     "convnext_xlarge_22k": "https://dl.fbaipublicfiles.com/convnext/convnext_xlarge_22k_224.pth",


### PR DESCRIPTION
Updated the url


Remarks,
There is some issue with model at ``` "convnext_xlarge_1k": "https://dl.fbaipublicfiles.com/convnext/convnext_xlarge_1k_224_ema.pth",```  I have updated the url and dict_key of model urls 
earlier the the 1K model of x_large wasn't loading I fixed that path and variable defined above but while executing I got the issue of 403 error

To further check if everything seems to work right or is it the issue of url only I tried downloading the model weights and using them and it gave me the following error ```PytorchStreamReader failed reading zip archive: failed finding central directory```

It seems that there is some issue with torch hub or model still dosen't exist at torch hub 