### PR TITLE
Add Weights and Biases Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We propose **ConvNeXt**, a pure ConvNet model constructed entirely from standard
 - [x] ImageNet-22K Pre-training Code  
 - [x] ImageNet-1K Fine-tuning Code  
 - [x] Downstream Transfer (Detection, Segmentation) Code
-- [x] ImageNet-1K Classification Web Demo [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/akhaliq/convnext)
+- [x] ImageNet Classification [Colab](https://colab.research.google.com/drive/1CBYTIZ4tBMsVL5cqu9N_-Q3TBprqsfEO?usp=sharing) and Web Demo [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/akhaliq/convnext)
 
 
 <!-- ✅ ⬜️  -->

--- a/datasets.py
+++ b/datasets.py
@@ -28,7 +28,7 @@ def build_dataset(is_train, args):
     print("---------------------------")
 
     if args.data_set == 'CIFAR':
-        dataset = datasets.CIFAR100(args.data_path, train=is_train, transform=transform)
+        dataset = datasets.CIFAR100(args.data_path, train=is_train, transform=transform, download=True)
         nb_classes = 100
     elif args.data_set == 'IMNET':
         print("reading from datapath", args.data_path)

--- a/engine.py
+++ b/engine.py
@@ -118,15 +118,15 @@ def train_one_epoch(model: torch.nn.Module, criterion: torch.nn.Module,
 
         if wandb_logger:
             wandb_logger._wandb.log({
-                'batch/train_loss': loss_value,
-                'batch/train_max_lr': max_lr,
-                'batch/train_min_lr': min_lr
+                'Rank-0 Batch Wise/train_loss': loss_value,
+                'Rank-0 Batch Wise/train_max_lr': max_lr,
+                'Rank-0 Batch Wise/train_min_lr': min_lr
             }, commit=False)
             if class_acc:
-                wandb_logger._wandb.log({'batch/train_class_acc': class_acc}, commit=False)
+                wandb_logger._wandb.log({'Rank-0 Batch Wise/train_class_acc': class_acc}, commit=False)
             if use_amp:
-                wandb_logger._wandb.log({'batch/train_grad_norm': grad_norm}, commit=False)
-            wandb_logger._wandb.log({'batch/global_train_step': it})
+                wandb_logger._wandb.log({'Rank-0 Batch Wise/train_grad_norm': grad_norm}, commit=False)
+            wandb_logger._wandb.log({'Rank-0 Batch Wise/global_train_step': it})
             
 
     # gather the stats from all processes

--- a/engine.py
+++ b/engine.py
@@ -18,7 +18,7 @@ def train_one_epoch(model: torch.nn.Module, criterion: torch.nn.Module,
                     data_loader: Iterable, optimizer: torch.optim.Optimizer,
                     device: torch.device, epoch: int, loss_scaler, max_norm: float = 0,
                     model_ema: Optional[ModelEma] = None, mixup_fn: Optional[Mixup] = None, log_writer=None,
-                    start_steps=None, lr_schedule_values=None, wd_schedule_values=None,
+                    wandb_logger=None, start_steps=None, lr_schedule_values=None, wd_schedule_values=None,
                     num_training_steps_per_epoch=None, update_freq=None, use_amp=False):
     model.train(True)
     metric_logger = utils.MetricLogger(delimiter="  ")
@@ -117,6 +117,19 @@ def train_one_epoch(model: torch.nn.Module, criterion: torch.nn.Module,
             if use_amp:
                 log_writer.update(grad_norm=grad_norm, head="opt")
             log_writer.set_step()
+
+        if wandb_logger:
+            wandb_logger._wandb.log({
+                'batch/train_loss': loss_value,
+                'batch/train_max_lr': max_lr,
+                'batch/train_min_lr': min_lr
+            }, commit=False)
+            if class_acc:
+                wandb_logger._wandb.log({'batch/train_class_acc': class_acc}, commit=False)
+            if use_amp:
+                wandb_logger._wandb.log({'batch/train_grad_norm': grad_norm}, commit=False)
+            wandb_logger._wandb.log({'batch/global_train_step': it})
+            
 
     # gather the stats from all processes
     metric_logger.synchronize_between_processes()

--- a/main.py
+++ b/main.py
@@ -397,10 +397,12 @@ def main(args):
             data_loader_train.sampler.set_epoch(epoch)
         if log_writer is not None:
             log_writer.set_step(epoch * num_training_steps_per_epoch * args.update_freq)
+        if wandb_logger:
+            wandb_logger.set_steps()
         train_stats = train_one_epoch(
             model, criterion, data_loader_train, optimizer,
             device, epoch, loss_scaler, args.clip_grad, model_ema, mixup_fn,
-            log_writer=log_writer, start_steps=epoch * num_training_steps_per_epoch,
+            log_writer=log_writer, wandb_logger=wandb_logger, start_steps=epoch * num_training_steps_per_epoch,
             lr_schedule_values=lr_schedule_values, wd_schedule_values=wd_schedule_values,
             num_training_steps_per_epoch=num_training_steps_per_epoch, update_freq=args.update_freq,
             use_amp=args.use_amp
@@ -457,7 +459,7 @@ def main(args):
                 f.write(json.dumps(log_stats) + "\n")
 
         if wandb_logger:
-            wandb_logger.log_metrics(log_stats)
+            wandb_logger.log_epoch_metrics(log_stats)
 
     if wandb_logger and args.wandb_ckpt and args.save_ckpt and args.output_dir:
         wandb_logger.log_checkpoints()

--- a/utils.py
+++ b/utils.py
@@ -226,9 +226,9 @@ class WandbLogger(object):
 
         for k, v in metrics.items():
             if 'train' in k:
-                self._wandb.log({f'train/{k}': v}, commit=False)
+                self._wandb.log({f'Global Train/{k}': v}, commit=False)
             elif 'test' in k:
-                self._wandb.log({f'test/{k}': v}, commit=False)
+                self._wandb.log({f'Global Test/{k}': v}, commit=False)
 
         self._wandb.log({})
 
@@ -242,11 +242,11 @@ class WandbLogger(object):
         self._wandb.log_artifact(model_artifact, aliases=["latest", "best"])
 
     def set_steps(self):
-        # Set global training setp
-        self._wandb.define_metric('batch/*', step_metric='batch/global_train_step')
+        # Set global training step
+        self._wandb.define_metric('Rank-0 Batch Wise/*', step_metric='Rank-0 Batch Wise/global_train_step')
         # Set epoch-wise step
-        self._wandb.define_metric('train/*', step_metric='epoch')
-        self._wandb.define_metric('test/*', step_metric='epoch')
+        self._wandb.define_metric('Global Train/*', step_metric='epoch')
+        self._wandb.define_metric('Global Test/*', step_metric='epoch')
 
 
 def setup_for_distributed(is_master):

--- a/utils.py
+++ b/utils.py
@@ -243,10 +243,8 @@ class WandbLogger(object):
 
     def set_steps(self):
         # Set global training setp
-        self._wandb.define_metric('batch/global_train_step')
         self._wandb.define_metric('batch/*', step_metric='batch/global_train_step')
         # Set epoch-wise step
-        self._wandb.define_metric('epoch')
         self._wandb.define_metric('train/*', step_metric='epoch')
         self._wandb.define_metric('test/*', step_metric='epoch')
 

--- a/utils.py
+++ b/utils.py
@@ -212,7 +212,7 @@ class WandbLogger(object):
                 config=args
             )
 
-    def log_metrics(self, metrics, commit=True):
+    def log_epoch_metrics(self, metrics, commit=True):
         """
         Log train/test metrics onto W&B.
         """
@@ -240,6 +240,15 @@ class WandbLogger(object):
 
         model_artifact.add_dir(output_dir)
         self._wandb.log_artifact(model_artifact, aliases=["latest", "best"])
+
+    def set_steps(self):
+        # Set global training setp
+        self._wandb.define_metric('batch/global_train_step')
+        self._wandb.define_metric('batch/*', step_metric='batch/global_train_step')
+        # Set epoch-wise step
+        self._wandb.define_metric('epoch')
+        self._wandb.define_metric('train/*', step_metric='epoch')
+        self._wandb.define_metric('test/*', step_metric='epoch')
 
 
 def setup_for_distributed(is_master):


### PR DESCRIPTION
This PR adds support for [Weights and Biases](https://wandb.ai/site) metric and model checkpointing.

# Usage

I have tested the implementation by training ConvNext Tiny on CIFAR 100 dataset for 10 epochs. To enable logging metrics using W&B use `--enable_wandb true`. To save the model checkpoints as versioned [artifacts](https://docs.wandb.ai/guides/artifacts/model-versioning) use `--wandb_ckpt true` along with `--enable_wandb`. 

```
python main.py --epochs 10 --model convnext_tiny --data_set CIFAR --data_path datasets --num_workers 8 --warmup_epochs 0  --save_ckpt true --output_dir model_ckpt --finetune path/to/model.pth --cutmix 0 --mixup 0 --lr 4e-4 --enable_wandb true --wandb_ckpt true
```

You can also set the name of the W&B project where all the runs will be logged using the `--project` argument (`default='convnext'`).

# Result (Feature Addition)

* Able to easily share the experiments. Here's an **[example W&B run](https://wandb.ai/ayush-thakur/convnext/runs/2aud3vtf)** that shows train and test metrics from fine-tuning a ConvNext tiny on CIFAR 100 for 10 epochs. 
* Ability to check out the exact configuration used to train the model. Configs can thus be easily compared. 
* CPU/GPU metrics - memory allocated, memory utilized, etc. 
* Versioned model checkpoints which are easy to share. 

Note: I achieved a ~88% test top 1 accuracy which is really impressive. Thanks for working on this. 

The screen recording below summarizes the features being added for a few lines of code. 

https://user-images.githubusercontent.com/31141479/150026875-91e4f38d-f465-49b6-9f12-3c8559c2934a.mov

# Note

* I have tested the implementation on a single machine with one GPU and with 2 GPUs and seems to work as expected. You can find the [W&B run](https://wandb.ai/ayush-thakur/convnext/runs/3gkbcdbq) associated with training on 2 K80s.
* If `--enable_wandb true` is not passed the code will work as expected, thus the addition is not enforcing any dependency on W&B.  

