### PR TITLE
Including a note on the TF/Keras models

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ This should give
 ## Training
 See [TRAINING.md](TRAINING.md) for training and fine-tuning instructions.
 
+## TensorFlow / Keras models
+Apart from the isotropic models, a total of 15 ConvNeXt models are available in TensorFlow / Keras. You can find them here:
+[sayakpaul/ConvNeXt-TF](https://github.com/sayakpaul/ConvNeXt-TF).
+
 ## Acknowledgement
 This repository is built using the [timm](https://github.com/rwightman/pytorch-image-models) library, [DeiT](https://github.com/facebookresearch/deit) and [BEiT](https://github.com/microsoft/unilm/tree/master/beit) repositories.
 


### PR DESCRIPTION
Hi!

Thanks for open-sourcing the model weights. In [this repository](https://github.com/sayakpaul/ConvNeXt-TF), I have independently implemented different variants of ConvNeXt in TensorFlow and Keras and populated the original weights into them. I have also verified their performance on the ImageNet-1k validation set. The results can be seen in [this table](https://github.com/sayakpaul/ConvNeXt-TF). 

I think these converted models might be useful for the community especially for those who use TensorFlow / Keras. 

