### PR TITLE
Fixed command line argument '--enable_wandb False' not actually disabling wandb.

### DIFF
--- a/main.py
+++ b/main.py
@@ -242,7 +242,7 @@ def main(args):
     else:
         log_writer = None
 
-    if global_rank == 0:
+    if global_rank == 0 and args.enable_wandb:
         wandb_logger = utils.WandbLogger(args)
     else:
         wandb_logger = None


### PR DESCRIPTION
Attempting to run

```
python main.py --model convnext_base --eval true \
--resume https://dl.fbaipublicfiles.com/convnext/convnext_base_22k_1k_224.pth \
--input_size 224 --drop_path 0.2 \
--data_path /path/to/imagenet --enable_wandb False
```

without wandb installed gives the error

```
Traceback (most recent call last):
  File "main.py", line 477, in <module>
    main(args)
  File "main.py", line 246, in main
    wandb_logger = utils.WandbLogger(args)
  File "/private/home/mintun/convnext/personal_fork/utils.py", line 203, in __init__
    raise ImportError(
ImportError: To use the Weights and Biases Logger please install wandb.Run `pip install wandb` to install it.
```

The value `args.enable_wandb` does not appear to be used anywhere to control usage of wandb.


Test:

```
python main.py --model convnext_base --eval true \
--resume https://dl.fbaipublicfiles.com/convnext/convnext_base_22k_1k_224.pth \
--input_size 224 --drop_path 0.2 \
--data_path /path/to/imagenet --enable_wandb False
```

performs single GPU eval without wandb installed, as expected.