### PR TITLE
Fix errors caused by out of sync with timm

### DIFF
--- a/models/convnext.py
+++ b/models/convnext.py
@@ -156,7 +156,7 @@ model_urls = {
 }
 
 @register_model
-def convnext_tiny(pretrained=False,in_22k=False, **kwargs):
+def convnext_tiny(pretrained=False, pretrained_cfg=None, in_22k=False, **kwargs):
     model = ConvNeXt(depths=[3, 3, 9, 3], dims=[96, 192, 384, 768], **kwargs)
     if pretrained:
         url = model_urls['convnext_tiny_22k'] if in_22k else model_urls['convnext_tiny_1k']
@@ -165,7 +165,7 @@ def convnext_tiny(pretrained=False,in_22k=False, **kwargs):
     return model
 
 @register_model
-def convnext_small(pretrained=False,in_22k=False, **kwargs):
+def convnext_small(pretrained=False, pretrained_cfg=None, in_22k=False, **kwargs):
     model = ConvNeXt(depths=[3, 3, 27, 3], dims=[96, 192, 384, 768], **kwargs)
     if pretrained:
         url = model_urls['convnext_small_22k'] if in_22k else model_urls['convnext_small_1k']
@@ -174,7 +174,7 @@ def convnext_small(pretrained=False,in_22k=False, **kwargs):
     return model
 
 @register_model
-def convnext_base(pretrained=False, in_22k=False, **kwargs):
+def convnext_base(pretrained=False, pretrained_cfg=None, in_22k=False, **kwargs):
     model = ConvNeXt(depths=[3, 3, 27, 3], dims=[128, 256, 512, 1024], **kwargs)
     if pretrained:
         url = model_urls['convnext_base_22k'] if in_22k else model_urls['convnext_base_1k']
@@ -183,7 +183,7 @@ def convnext_base(pretrained=False, in_22k=False, **kwargs):
     return model
 
 @register_model
-def convnext_large(pretrained=False, in_22k=False, **kwargs):
+def convnext_large(pretrained=False, pretrained_cfg=None, in_22k=False, **kwargs):
     model = ConvNeXt(depths=[3, 3, 27, 3], dims=[192, 384, 768, 1536], **kwargs)
     if pretrained:
         url = model_urls['convnext_large_22k'] if in_22k else model_urls['convnext_large_1k']
@@ -192,7 +192,7 @@ def convnext_large(pretrained=False, in_22k=False, **kwargs):
     return model
 
 @register_model
-def convnext_xlarge(pretrained=False, in_22k=False, **kwargs):
+def convnext_xlarge(pretrained=False, pretrained_cfg=None, in_22k=False, **kwargs):
     model = ConvNeXt(depths=[3, 3, 27, 3], dims=[256, 512, 1024, 2048], **kwargs)
     if pretrained:
         assert in_22k, "only ImageNet-22K pre-trained ConvNeXt-XL is available; please set in_22k=True"

--- a/optim_factory.py
+++ b/optim_factory.py
@@ -14,7 +14,6 @@ from timm.optim.adahessian import Adahessian
 from timm.optim.adamp import AdamP
 from timm.optim.lookahead import Lookahead
 from timm.optim.nadam import Nadam
-from timm.optim.novograd import NovoGrad
 from timm.optim.nvnovograd import NvNovoGrad
 from timm.optim.radam import RAdam
 from timm.optim.rmsprop_tf import RMSpropTF
@@ -168,8 +167,6 @@ def create_optimizer(args, model, get_num_layer=None, get_layer_scale=None, filt
         optimizer = optim.RMSprop(parameters, alpha=0.9, momentum=args.momentum, **opt_args)
     elif opt_lower == 'rmsproptf':
         optimizer = RMSpropTF(parameters, alpha=0.9, momentum=args.momentum, **opt_args)
-    elif opt_lower == 'novograd':
-        optimizer = NovoGrad(parameters, **opt_args)
     elif opt_lower == 'nvnovograd':
         optimizer = NvNovoGrad(parameters, **opt_args)
     elif opt_lower == 'fusedsgd':


### PR DESCRIPTION
1. Fix the module not found error. The timm removed Novograd a long time ago (18 Aug 2021) and replaced it with Nvnovograd, which is already presented in the code. 

https://github.com/rwightman/pytorch-image-models/commit/ac469b50da310546d1148ad8038aca92c1488a92#:~:text=Remove%20novograd.py%20impl%20as%20it%20was%20messy%2C%20keep%20nvnovograd

2.  Fix TypeError: __init__() got an unexpected keyword argument 'pretrained_cfg'. After the func create_model in main.py is called, the func create_fn of timm provides a parameter pretrained_cfg, which is needed in each model create method.

https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/factory.py#:~:text=model%20%3D%20create_fn(pretrained%3Dpretrained%2C%20pretrained_cfg%3Dpretrained_cfg%2C%20**kwargs)
